### PR TITLE
Bug fix for Issue #1 in which, when attempting to retrieve XElement in T...

### DIFF
--- a/Framework/Messages/MessageContext.cs
+++ b/Framework/Messages/MessageContext.cs
@@ -232,7 +232,12 @@ namespace EdiFabric.Framework.Messages
                 throw new ParserException("Can't find GS segment.");
             }
 
-            var tag = st.Element(ns + EdiElements.StTag) ?? st.Element(ns + EdiElements.StTagHipaa);
+            XElement tag = null;
+            if (st.Descendants().Where(x => x.Name.LocalName.IndexOf(EdiElements.StTag) != -1).Any()) {
+                tag = st.Descendants().Where(x => x.Name.LocalName.IndexOf(EdiElements.StTag) != -1).First();
+            } else if (st.Descendants().Where(x => x.Name.LocalName.IndexOf(EdiElements.StTagHipaa) != -1).Any()) {
+                tag = st.Descendants().Where(x => x.Name.LocalName.IndexOf(EdiElements.StTagHipaa) != -1).First();
+            }
 
             if (tag == null)
             {


### PR DESCRIPTION
Bug fix for Issue #1 in which, when attempting to retrieve XElement in ToContextX12(), EdiElements.StTagHipaa is "D_ST01" but the public field as defined in Definitions/005010_834.cs is "D_ST01_TransactionSetIdentifierCode", causing an incorrect null assignment. Hard-coding the full field name fixes the problem so the incorrect name is verified to be the problem. This fix searches for any XElements in which the name simply begins with either EdiElements.StTag or EdiElements.StTagHipaa.