### PR TITLE
Resolve error “EdiFabric.Framework.XmlSerializers” cannot load

### DIFF
--- a/Framework/EdiHelper.cs
+++ b/Framework/EdiHelper.cs
@@ -66,7 +66,15 @@ namespace EdiFabric.Framework
             // Fix: using instance.GetType() instead of typeof(T)
             var type = instance.GetType();
 
-            var serializer = new XmlSerializer(type, GetNamespace(type));
+            //this throws an error via netFramework because the netFW tries to load the assembly from disc like described in http://edifabric.com/answers/error-edifabric-framework-xmlserializers-can-load/ or in the commit description
+            //var serializer = new XmlSerializer(type, GetNamespace(type));
+
+            //so it is better to generate the assembly by ourselves because we know the file searched for by the netFW isn't there
+            string defaultNamespace = GetNamespace(type);
+            XmlReflectionImporter importer = new XmlReflectionImporter(defaultNamespace);
+            XmlTypeMapping xmltm = importer.ImportTypeMapping(type, null, defaultNamespace);
+            var serializer = new XmlSerializer(xmltm);
+
             using (var ms = new MemoryStream())
             {
                 serializer.Serialize(ms, instance);


### PR DESCRIPTION
This error occurs if you register for extended error handling in your application (AppDomain.CurrentDomain.FirstChanceException += CurrentDomain_FirstChanceException;); see also http://edifabric.com/answers/error-edifabric-framework-xmlserializers-can-load/.
It doesn't occur in EdiFabric framework itself. It's because the MS framework searches for the assembly in XmlSerializer.cs when calling var serializer = new XmlSerializer(type, GetNamespace(type)); in EdiHelper.cs (you can debug this through VS2013/2015 with some special debugging settings and using the parallel stacks window in the debugger).
The code of XmlSerializer.cs can be seen in http://referencesource.microsoft.com/#System.Xml/System/Xml/Serialization/XmlSerializer.cs, it's line 198. From there it goes to http://referencesource.microsoft.com/#System.Xml/System/Xml/Serialization/Compilation.cs, Line 150 where it tries to load the file from disk in Compilation.cs, line 173 which fails and throws the error.

Therefore it's better to generate the tempAssembly by ourselves because we know the file isn't there ;-) By the way we can gain small performance improvements :-) So I suggest to change the code in EdiHelper.cs.